### PR TITLE
Item detail

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:edit, :show]
 
   def index
     @items = Item.order('created_at DESC')
@@ -21,8 +22,8 @@ class ItemsController < ApplicationController
   # def edit
   # end
 
-  # def show
-  # end
+  def show
+  end
 
   private
 
@@ -30,4 +31,9 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :memo, :category_id, :condition_id, :price, :days_to_ship_id, :shipping_fee_id,
                                  :ship_from_id, :ship_to_id, :image).merge(user_id: current_user.id)
   end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,5 +35,4 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,23 +6,21 @@ class Item < ApplicationRecord
     validates :image
     validates :name
     validates :memo
-    validates :price,            numericality: { only_integer: true, greater_than: 300, less_than: 10000000}
+    validates :price,            numericality: { only_integer: true, greater_than: 300, less_than: 10_000_000 }
     validates :price,            format: { with: /\A[0-9]+\z/, message: 'is invalid. Input half-width numbers.' }
     with_options numericality: { other_than: 1 } do
-      validates :category_id      
+      validates :category_id
       validates :condition_id
       validates :days_to_ship_id
       validates :shipping_fee_id
       validates :ship_from_id
-    end 
+    end
   end
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-    belongs_to :category
-    belongs_to :condition
-    belongs_to :shipping_fee
-    belongs_to :ship_from
-    belongs_to :days_to_ship
-  end
-
-
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :shipping_fee
+  belongs_to :ship_from
+  belongs_to :days_to_ship
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,3 @@ class User < ApplicationRecord
     validates :password, format: { with: VALID_PASSWORD_REGEX, message: '半角英数字混合を入力してください' }
   end
 end
-

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <% if @items[0]!= nil %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to '#' do %>
+            <%= link_to item_path(item.id) do %>
             <%= image_tag item.image, class: "item-img" %>
             <div class='item-info'>
               <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,9 @@
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %> 
     <% end %>
 
+   <% if user_signed_in? && current_user.id != @item.user_id%>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn" %>
+   <% end %> 
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" %>
@@ -34,7 +34,7 @@
    <% end %> 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.memo %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -99,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,34 +7,29 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" if item.image.attached? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう 商品購入機能実装後に実装 %>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
+      <%# //商品が売れている場合は、sold outを表示しましょう 商品購入機能実装後に実装 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円(税込み)
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %> 
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %> 
+    <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn" %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +38,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.ship_from.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,20 +1,17 @@
 FactoryBot.define do
   factory :item do
-    name             {"hoge"}
-    memo             {Faker::Lorem.sentence}
-    category_id      {2}
-    condition_id     {2}
-    price            {10000}
-    days_to_ship_id  {2}
-    shipping_fee_id  {2}
-    ship_from_id     {2}
+    name             { 'hoge' }
+    memo             { Faker::Lorem.sentence }
+    category_id      { 2 }
+    condition_id     { 2 }
+    price            { 10_000 }
+    days_to_ship_id  { 2 }
+    shipping_fee_id  { 2 }
+    ship_from_id     { 2 }
     association :user
-
 
     after(:build) do |message|
       message.image.attach(io: File.open('public/images/IMG_5794.jpeg'), filename: 'IMG_5794.jpeg')
     end
-
   end
 end
-

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Item, type: :model do
 
   describe '商品出品機能' do
     context '商品出品がうまくいくとき' do
-       it 'name,memo,category_id,condition_id,price,days_to_ship_id,shipping_fee_id,ship_from_idが存在すれば登録できる' do
+      it 'name,memo,category_id,condition_id,price,days_to_ship_id,shipping_fee_id,ship_from_idが存在すれば登録できる' do
         expect(@item).to be_valid
       end
     end
@@ -25,12 +25,12 @@ RSpec.describe Item, type: :model do
       it 'category_idが1だと登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it 'condition_idが1だと登録できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
       it 'priceが空だと登録できない' do
         @item.price = ''
@@ -40,32 +40,32 @@ RSpec.describe Item, type: :model do
       it 'priceが299円以下空だと登録できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than 300')
       end
       it 'priceが10,000,000円以上だと登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than 10000000")
+        expect(@item.errors.full_messages).to include('Price must be less than 10000000')
       end
       it 'priceが全角数字だと登録できない' do
         @item.price = '５００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'days_to_ship_idが1だと登録できない' do
         @item.days_to_ship_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Days to ship must be other than 1")
+        expect(@item.errors.full_messages).to include('Days to ship must be other than 1')
       end
       it 'shipping_fee_idが1だと登録できない' do
         @item.shipping_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping fee must be other than 1')
       end
       it 'ship_from_idが1だと登録できない' do
         @item.ship_from_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Ship from must be other than 1")
+        expect(@item.errors.full_messages).to include('Ship from must be other than 1')
       end
       it '画像がない場合は登録できない' do
         @item.image = nil


### PR DESCRIPTION
# What
商品詳細表示画面の作成

# Why
商品詳細表示機能の実装

# 実装条件（機能ごとの画面の遷移）

・ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://gyazo.com/b23382924c7b303e5958d863a30325cb

・ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/da9f4a078a04f5aa8e3798a507454fb7

・ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
・ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
・画像が表示されており、画像がリンク切れなどになっていないこと
https://gyazo.com/30520dd91bd208e4c5c916ca886e666d

・商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/fa12bc8e4f7cd45c824e0779d4fbf500
https://gyazo.com/413267b8bfd69a4087ce0734f475a98d

・ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
・売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
　→商品購入機能未実装（購入記録のテーブルがない）ため、この機能に関しては未実装です

